### PR TITLE
Missing expectMultiPart(true); in Scala docs

### DIFF
--- a/docs_md/core_manual_scala.md
+++ b/docs_md/core_manual_scala.md
@@ -1447,12 +1447,16 @@ Here's an example using `bodyHandler`:
 #### Handling Multipart Form Uploads
 
 Vert.x understands file uploads submitted from HTML forms in browsers. In order to handle file uploads you should set the `uploadHandler` on the request. The handler will be called once for each upload in the form.
+  
+    request.expectMultiPart(true);
 
     request.uploadHandler({ upload: HttpServerFileUpload => })
 
 The `HttpServerFileUpload` class implements `ReadStream` so you read the data and stream it to any object that implements `WriteStream` using a Pump, as previously discussed.
 
 You can also stream it directly to disk using the convenience method `streamToFileSystem()`.
+
+    request.expectMultiPart(true);
 
     request.uploadHandler({ upload: HttpServerFileUpload =>
     	upload.streamToFileSystem("uploads/" + upload.filename())


### PR DESCRIPTION
When you make a Multipart Form Upload you have to call "request.expectMultiPart(true);" before you register the handler. This line of code is currently missing in the Scala docs. I added it to both code examples like it is in the Java docs.
