### PR TITLE
fix docs: [Scala] accept-all in eventbus bridge

### DIFF
--- a/docs_md/core_manual_scala.md
+++ b/docs_md/core_manual_scala.md
@@ -2257,8 +2257,9 @@ The following example bridges the event bus to client side JavaScript:
     val server = vertx.createHttpServer()
     
     val config = Json.obj("prefix" -> "/echo")
-    
-    vertx.createSockJSServer(server).bridge(config, new JsonArray(), new JsonArray())
+    val permitAll = new JsonArray()
+    permitAll.add(new JsonObject())
+    vertx.createSockJSServer(server).bridge(config, permitAll, permitAll)
     
     server.listen(8080)
     


### PR DESCRIPTION
The "Allow-all" configuration of sockjs eventbus bridge is a JsonArray with inside an empty JsonObject. Passing an empty JsonArray won't allow anything to pass. Tricky API.
