### PR TITLE
fix flow control examples to not discard buffer when queue is full

### DIFF
--- a/docs_md/core_manual_clojure.md
+++ b/docs_md/core_manual_clojure.md
@@ -1719,9 +1719,9 @@ write queue gets full. What we really want to do is pause the
           (fn [sock]
             (stream/on-data sock
               (fn [buffer]
+                (stream/write sock buffer)
                 (if (.writeQueueFull sock)
-                  (.pause sock)
-                  (stream/write sock buffer))))))
+                  (.pause sock))))))
         (net/listen 1234 "localhost"))
     
 We're almost there, but not quite. The `NetSocket` now gets paused
@@ -1733,11 +1733,11 @@ write queue has processed its backlog:
           (fn [sock]
             (stream/on-data sock
               (fn [buffer]
+                (stream/write sock buffer)
                 (if (.writeQueueFull sock)
                   (do 
                     (.pause sock)
-                    (stream/on-drain #(.resume sock)))
-                  (stream/write sock buffer))))))
+                    (stream/on-drain #(.resume sock))))))))
         (net/listen 1234 "localhost"))
         
 And there we have it. The `drain_handler` event handler will get

--- a/docs_md/core_manual_groovy.md
+++ b/docs_md/core_manual_groovy.md
@@ -1064,9 +1064,8 @@ This example won't run out of RAM but we'll end up losing data if the write queu
 
     server.connectHandler { sock ->
         sock.dataHandler { buffer ->
-            if (!sock.writeQueueFull) {
-                sock.write(buffer)
-            } else {
+            sock.write(buffer)
+            if (sock.writeQueueFull) {
                 sock.pause()
             }
         }
@@ -1078,9 +1077,8 @@ We're almost there, but not quite. The `NetSocket` now gets paused when the file
 
     server.connectHandler { sock ->
         sock.dataHandler { buffer ->
-            if (!sock.writeQueueFull) {
-                sock.write(buffer)
-            } else {
+            sock.write(buffer)
+            if (sock.writeQueueFull) {
                 sock.pause()
                 sock.drainHandler { sock.resume() }
             }

--- a/docs_md/core_manual_java.md
+++ b/docs_md/core_manual_java.md
@@ -1512,9 +1512,8 @@ This example won't run out of RAM but we'll end up losing data if the write queu
 
             sock.dataHandler(new Handler<Buffer>() {
                 public void handle(Buffer buffer) {
-                    if (!sock.writeQueueFull()) {
-                        sock.write(buffer);
-                    } else {
+                    sock.write(buffer);
+                    if (sock.writeQueueFull()) {
                         sock.pause();
                     }
                 }
@@ -1532,9 +1531,8 @@ We're almost there, but not quite. The `NetSocket` now gets paused when the file
 
             sock.dataHandler(new Handler<Buffer>() {
                 public void handle(Buffer buffer) {
-                    if (!sock.writeQueueFull()) {
-                        sock.write(buffer);
-                    } else {
+                    sock.write(buffer);
+                    if (sock.writeQueueFull()) {
                         sock.pause();
                         sock.drainHandler(new VoidHandler() {
                             public void handle() {

--- a/docs_md/core_manual_js.md
+++ b/docs_md/core_manual_js.md
@@ -1155,9 +1155,8 @@ This example won't run out of RAM but we'll end up losing data if the write queu
     
         sock.dataHandler(function(buffer) {
       
-            if (!sock.writeQueueFull()) {      
-                sock.write(buffer); 
-            } else {
+            sock.write(buffer); 
+            if (sock.writeQueueFull()) {      
                 sock.pause();
             }
         });
@@ -1172,9 +1171,8 @@ We're almost there, but not quite. The `NetSocket` now gets paused when the file
     
         sock.dataHandler(function(buffer) {
       
-            if (!sock.writeQueueFull()) {      
-                sock.write(buffer); 
-            } else {
+            sock.write(buffer); 
+            if (sock.writeQueueFull()) {      
                 sock.pause();
                 
                 sock.drainHandler(function() {

--- a/docs_md/core_manual_python.md
+++ b/docs_md/core_manual_python.md
@@ -1134,10 +1134,9 @@ This example won't run out of RAM but we'll end up losing data if the write queu
     def connect_handler(sock):
 	@sock.data_handler
         def data_handler(buffer):
+            sock.write(buffer)
             if sock.write_queue_full:
                 sock.pause()
-            else:
-                sock.write(buffer)
        
     server.listen(1234, 'localhost')
 
@@ -1150,13 +1149,12 @@ We're almost there, but not quite. The `NetSocket` now gets paused when the file
     def connect_handler(sock):
 	@sock.data_handler
         def data_handler(buffer):
+            sock.write(buffer)
             if sock.write_queue_full:
                 sock.pause()
                 @sock.drain_handler
                 def drain_handler(): 
                	    sock.resume()
-            else:
-                sock.write(buffer)
             
     server.listen(1234, 'localhost')
 

--- a/docs_md/core_manual_ruby.md
+++ b/docs_md/core_manual_ruby.md
@@ -1076,10 +1076,9 @@ This example won't run out of RAM but we'll end up losing data if the write queu
 
         sock.data_handler do |buffer|
 
+            sock.write(buffer)
             if sock.write_queue_full?
                 sock.pause
-            else
-                sock.write(buffer)
             end
             
         end
@@ -1094,11 +1093,10 @@ We're almost there, but not quite. The `NetSocket` now gets paused when the file
 
         sock.data_handler do |buffer|
 
+            sock.write(buffer)
             if sock.write_queue_full?
                 sock.pause
                 sock.drain_handler { sock.resume }
-            else
-                sock.write(buffer)
             end
             
         end

--- a/docs_md/core_manual_scala.md
+++ b/docs_md/core_manual_scala.md
@@ -1172,9 +1172,8 @@ This example won't run out of RAM but we'll end up losing data if the write queu
 
     vertx.createNetServer.connectHandler({ sock: NetSocket =>
 		sock.dataHandler({ buffer: Buffer
-			if (!sock.writeQueueFull()) {
-				sock.write(buffer)
-       		} else {
+			sock.write(buffer)
+			if (sock.writeQueueFull()) {
              	sock.pause()
        		}
 		})
@@ -1184,9 +1183,8 @@ We're almost there, but not quite. The `NetSocket` now gets paused when the file
 
     vertx.createNetServer.connectHandler({ sock: NetSocket =>
     	sock.dataHandler({ buffer: Buffer =>
-			if (!sock.writeQueueFull()) {
-            	sock.write(buffer)
-        	} else {
+            sock.write(buffer)
+			if (sock.writeQueueFull()) {
             	sock.pause()
             	sock.drainHandler({
                 	sock.resume()


### PR DESCRIPTION
moved the write operations outside the if in the different language examples
