### PR TITLE
Sonatype snapshots should use a https url

### DIFF
--- a/mods_manual.html
+++ b/mods_manual.html
@@ -363,7 +363,7 @@ mavenLocal:~/.m2/repository
 maven:http://repo2.maven.org/maven2
 
 # Sonatype snapshots
-maven:http://oss.sonatype.org/content/repositories/snapshots
+maven:https://oss.sonatype.org/content/repositories/snapshots
 
 # Bintray
 bintray:http://dl.bintray.com


### PR DESCRIPTION
see https://bugs.eclipse.org/bugs/show_bug.cgi?id=437309

It's changed in upstream code already so docs should be put back in sync:
https://github.com/eclipse/vert.x/blob/2.x/vertx-platform/src/main/resources/default-repos.txt
