### PR TITLE
req.response() -> req.response in Rhino manual

### DIFF
--- a/core_manual_js.html
+++ b/core_manual_js.html
@@ -1725,11 +1725,11 @@ server.requestHandler(routeMatcher).listen(8080, 'localhost');
 var routeMatcher = new vertx.RouteMatcher();
 
 routeMatcher.get('/animals/dogs', function(req) {
-    req.response().end('You requested dogs');
+    req.response.end('You requested dogs');
 });
 
 routeMatcher.get('/animals/cats', function(req) {
-    req.response().end('You requested cats');    
+    req.response.end('You requested cats');    
 });
 
 server.requestHandler(routeMatcher).listen(8080, 'localhost');
@@ -1748,7 +1748,7 @@ var routeMatcher = new vertx.RouteMatcher();
 routeMatcher.put('/:blogname/:post', function(req) {        
     var blogName = req.params().get('blogname');
     var post = req.params().get('post');
-    req.response().end('blogname is ' + blogName + ', post is ' + post);
+    req.response.end('blogname is ' + blogName + ', post is ' + post);
 });
 
 server.requestHandler(routeMatcher).listen(8080, 'localhost');
@@ -1779,7 +1779,7 @@ server.requestHandler(routeMatcher).listen(8080, 'localhost');
 <h2 id="handling-requests-where-nothing-matches">Handling requests where nothing matches</h2><br/>
 <p>You can use the <code>noMatch</code> method to specify a handler that will be called if nothing matches. If you don't specify a no match handler and nothing matches, a 404 will be returned.</p>
 <pre class="prettyprint">routeMatcher.noMatch(function(req) {
-    req.response().end('Nothing matched');
+    req.response.end('Nothing matched');
 });
 </pre>
 <h1 id="websockets">WebSockets</h1><br/>

--- a/docs_md/core_manual_js.md
+++ b/docs_md/core_manual_js.md
@@ -1982,11 +1982,11 @@ You can then add different matches to the route matcher. For example, to send al
     var routeMatcher = new vertx.RouteMatcher();
     
     routeMatcher.get('/animals/dogs', function(req) {
-        req.response().end('You requested dogs');
+        req.response.end('You requested dogs');
     });
     
     routeMatcher.get('/animals/cats', function(req) {
-        req.response().end('You requested cats');    
+        req.response.end('You requested cats');    
     });
         
     server.requestHandler(routeMatcher).listen(8080, 'localhost');
@@ -2012,7 +2012,7 @@ If you want to extract parameters from the path, you can do this too, by using t
     routeMatcher.put('/:blogname/:post', function(req) {        
         var blogName = req.params().get('blogname');
         var post = req.params().get('post');
-        req.response().end('blogname is ' + blogName + ', post is ' + post);
+        req.response.end('blogname is ' + blogName + ', post is ' + post);
     });
     
     server.requestHandler(routeMatcher).listen(8080, 'localhost');
@@ -2056,7 +2056,7 @@ It will display 'first is animals and second is cats'.
 You can use the `noMatch` method to specify a handler that will be called if nothing matches. If you don't specify a no match handler and nothing matches, a 404 will be returned.
 
     routeMatcher.noMatch(function(req) {
-        req.response().end('Nothing matched');
+        req.response.end('Nothing matched');
     });
     
 # WebSockets


### PR DESCRIPTION
Update Rhino manual to treat req.response as an object rather than a function, to match reality